### PR TITLE
Add script to renew Tailscale SSL certificates

### DIFF
--- a/renew-tailscale-cert.sh
+++ b/renew-tailscale-cert.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+CERT_DIR="/etc/ssl/tailscale"
+
+# Obtain DNS name for this machine in the tailnet
+DNS_NAME=$(tailscale status --json | jq -r '.Self.DNSName')
+
+CERT_FILE="${CERT_DIR}/${DNS_NAME}.crt"
+KEY_FILE="${CERT_DIR}/${DNS_NAME}.key"
+
+mkdir -p "$CERT_DIR"
+
+renew_needed=false
+
+if [[ ! -f "$CERT_FILE" || ! -f "$KEY_FILE" ]]; then
+  renew_needed=true
+else
+  # Extract certificate expiration date and compute remaining days
+  if ! END_DATE=$(openssl x509 -enddate -noout -in "$CERT_FILE" 2>/dev/null | cut -d= -f2); then
+    renew_needed=true
+  else
+    END_SECS=$(date -d "$END_DATE" +%s)
+    NOW_SECS=$(date +%s)
+    DAYS_LEFT=$(( (END_SECS - NOW_SECS) / 86400 ))
+    if (( DAYS_LEFT < 20 )); then
+      renew_needed=true
+    fi
+  fi
+fi
+
+if [ "$renew_needed" = true ]; then
+  echo "Generating new certificate for $DNS_NAME"
+  tailscale cert --cert-file="$CERT_FILE" --key-file="$KEY_FILE" "$DNS_NAME"
+else
+  echo "Certificate for $DNS_NAME is valid for $DAYS_LEFT days."
+fi


### PR DESCRIPTION
## Summary
- add shell script that checks Tailscale certificate presence and expiration
- regenerate certificate with `tailscale cert` if missing or due to expire

## Testing
- `bash -n renew-tailscale-cert.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a5bf49dbd8833393be4239afafba6d